### PR TITLE
Chore: JPA N+1 Detector 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,12 +21,14 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa' // Spring Data JPA
     implementation 'org.springframework.boot:spring-boot-starter-web' // Spring MVC
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0' // OpenAPI (Swagger UI)
+    implementation 'com.github.joon6093:jpa-nplus1-detector:2.2.0' // JPA N+1 detector
 
     compileOnly 'org.projectlombok:lombok' // Lombok (code generation)
     annotationProcessor 'org.projectlombok:lombok' // Lombok annotation processor

--- a/build.gradle
+++ b/build.gradle
@@ -24,14 +24,17 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
-    compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.mysql:mysql-connector-j'
-    annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa' // Spring Data JPA
+    implementation 'org.springframework.boot:spring-boot-starter-web' // Spring MVC
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0' // OpenAPI (Swagger UI)
+
+    compileOnly 'org.projectlombok:lombok' // Lombok (code generation)
+    annotationProcessor 'org.projectlombok:lombok' // Lombok annotation processor
+
+    runtimeOnly 'com.mysql:mysql-connector-j' // MySQL driver
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test' // Spring Boot testing
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher' // JUnit platform launcher
 }
 
 tasks.named('test') {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:33306/ziine?useUnicode=true&characterEncoding=utf8&serverTimezone=UTC
+    username: root
+    password: password
+
+  jpa:
+    generate-ddl: true
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        order_inserts: true
+        order_updates: true
+        format_sql: true
+    open-in-view: false

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,6 +4,8 @@ spring:
     url: jdbc:mysql://localhost:33306/ziine?useUnicode=true&characterEncoding=utf8&serverTimezone=UTC
     username: root
     password: password
+    hikari:
+      auto-commit: false
 
   jpa:
     generate-ddl: true
@@ -15,4 +17,5 @@ spring:
         order_inserts: true
         order_updates: true
         format_sql: true
+        query.fail_on_pagination_over_collection_fetch: true
     open-in-view: false

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -18,4 +18,9 @@ spring:
         order_updates: true
         format_sql: true
         query.fail_on_pagination_over_collection_fetch: true
+        detector:
+          enabled: true
+          threshold: 2
+          level: warn
+          exclude:
     open-in-view: false

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -4,6 +4,9 @@ spring:
     url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useUnicode=true&characterEncoding=utf8&serverTimezone=UTC
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+    hikari:
+      auto-commit: false
+
   jpa:
     generate-ddl: false
     hibernate:
@@ -14,4 +17,5 @@ spring:
         order_inserts: true
         order_updates: true
         format_sql: true
+        query.fail_on_pagination_over_collection_fetch: true
     open-in-view: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,17 +1,9 @@
+server:
+  port: 8080
+
 spring:
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:33306/ziine?useUnicode=true&characterEncoding=utf8&serverTimezone=UTC
-    username: root
-    password: password
-  jpa:
-    generate-ddl: true
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    properties:
-      hibernate:
-        order_inserts: true
-        order_updates: true
-        format_sql: true
-    open-in-view: false
+  profiles:
+    default: local
+
+  application:
+    name: ziine


### PR DESCRIPTION
## PR 요약  
JPA N+1 Detector 적용 및 환경 설정 분리  

#### 📌 변경 사항  
- JPA N+1 Detector 라이브러리 추가 (com.github.joon6093:jpa-nplus1-detector:2.2.0)  
- 환경별 설정 분리 
  - application-local.yml: 로컬 환경에서만 N+1 Detector 활성화 설정
  - application-prod.yml: N+1 Detector는 기본값이 동작하지 않음이기 때문에 프로덕션 환경에서는 동작하지 않음
- Hibernate 설정 추가  
  - query.fail_on_pagination_over_collection_fetch: true → 컬렉션 페치 시 페이징 금지  
- 데이터베이스 설정 개선  
  - HikariCP의 auto-commit: false 설정  

##### ✅ PR check list  
로컬환경에서 애플리케이션 실행 시, 아래 로그가 출력되며 N+1 Detector가 정상적으로 활성화됨을 확인할 수 있습니다.  
```
2025-02-03T22:38:20.716+09:00  INFO 42480 --- [ziine] [           main] i.j.d.c.NPlusOneDetectorLoggingConfig    : N+1 Detector enabled in 'LOGGING' mode. Monitoring queries with a threshold of '2' and logging at 'warn' level.
```

이 설정을 통해 로컬 환경에서 N+1 문제를 감지하고, 로그를 통해 확인할 수 있습니다.
의견 및 피드백 환영합니다! 🚀
