### PR TITLE
Feat: Artwork 검토 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa' // Spring Data JPA
     implementation 'org.springframework.boot:spring-boot-starter-web' // Spring MVC
+    implementation 'org.springframework.boot:spring-boot-starter-validation' // Spring Validation
+    
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0' // OpenAPI (Swagger UI)
     implementation 'com.github.joon6093:jpa-nplus1-detector:2.2.0' // JPA N+1 detector
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,9 @@ services:
       - ./db/mysql/data:/var/lib/mysql
       - ./db/mysql/init:/docker-entrypoint-initdb.d
     command:
-      - '--character-set-server=utf8mb4'
-      - '--collation-server=utf8mb4_unicode_ci'
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --skip-character-set-client-handshake
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: ziine

--- a/src/main/java/com/ziine/admin/application/ArtworkReviewService.java
+++ b/src/main/java/com/ziine/admin/application/ArtworkReviewService.java
@@ -33,4 +33,20 @@ public class ArtworkReviewService { // TODO. 추후 Spring Event 방식으로 �
         ));
     }
 
+    @Transactional
+    public void rejectArtwork(
+        final Long artworkId,
+        final ArtworkRejectRequestDto artworkRejectRequestDto
+    ) {
+        final ArtworkEntity artworkEntity = artworkRepository.findById(artworkId)
+            .orElseThrow(
+                () -> new BusinessException(ErrorCode.ARTWORK_NOT_FOUND)); // TODO. ArtworkNotFoundException 으로 변경
+
+        final ArtworkStatus fromStatus = artworkEntity.getStatus();
+        artworkEntity.updateStatus(ArtworkStatus.REJECTED);
+
+        artworkStatusHistoryRepository.save(new ArtworkStatusHistoryEntity(
+            fromStatus, ArtworkStatus.REJECTED, artworkRejectRequestDto.rejectionReason(), "TODO", artworkEntity
+        ));
+    }
 }

--- a/src/main/java/com/ziine/admin/application/ArtworkReviewService.java
+++ b/src/main/java/com/ziine/admin/application/ArtworkReviewService.java
@@ -1,0 +1,36 @@
+package com.ziine.admin.application;
+
+import com.ziine.admin.application.dto.request.ArtworkRejectRequestDto;
+import com.ziine.admin.domain.entity.ArtworkStatusHistoryEntity;
+import com.ziine.admin.domain.repository.ArtworkStatusHistoryRepository;
+import com.ziine.artwork.domain.entity.ArtworkEntity;
+import com.ziine.artwork.domain.entity.ArtworkStatus;
+import com.ziine.artwork.domain.repository.ArtworkRepository;
+import com.ziine.common.exception.BusinessException;
+import com.ziine.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class ArtworkReviewService { // TODO. 추후 Spring Event 방식으로 변경하여 상태 변경을 저장하는 보조 관심사 분리
+
+    private final ArtworkRepository artworkRepository;
+    private final ArtworkStatusHistoryRepository artworkStatusHistoryRepository;
+
+    @Transactional
+    public void approveArtwork(final Long artworkId) {
+        final ArtworkEntity artworkEntity = artworkRepository.findById(artworkId)
+            .orElseThrow(
+                () -> new BusinessException(ErrorCode.ARTWORK_NOT_FOUND)); // TODO. ArtworkNotFoundException 으로 변경
+
+        final ArtworkStatus fromStatus = artworkEntity.getStatus();
+        artworkEntity.updateStatus(ArtworkStatus.APPROVED);
+
+        artworkStatusHistoryRepository.save(new ArtworkStatusHistoryEntity(
+            fromStatus, ArtworkStatus.APPROVED, null, "TODO", artworkEntity
+        ));
+    }
+
+}

--- a/src/main/java/com/ziine/admin/application/dto/request/ArtworkRejectRequestDto.java
+++ b/src/main/java/com/ziine/admin/application/dto/request/ArtworkRejectRequestDto.java
@@ -1,0 +1,10 @@
+package com.ziine.admin.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ArtworkRejectRequestDto(
+    @NotBlank(message = "Rejection reason is required")
+    String rejectionReason
+) {
+
+}

--- a/src/main/java/com/ziine/admin/domain/entity/ArtworkStatusHistoryEntity.java
+++ b/src/main/java/com/ziine/admin/domain/entity/ArtworkStatusHistoryEntity.java
@@ -1,5 +1,7 @@
-package com.ziine.artwork.domain.entity;
+package com.ziine.admin.domain.entity;
 
+import com.ziine.artwork.domain.entity.ArtworkEntity;
+import com.ziine.artwork.domain.entity.ArtworkStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/ziine/admin/domain/entity/ArtworkStatusHistoryEntity.java
+++ b/src/main/java/com/ziine/admin/domain/entity/ArtworkStatusHistoryEntity.java
@@ -30,7 +30,7 @@ public class ArtworkStatusHistoryEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "history_id")
+    @Column(name = "artwork_status_history_id")
     private Long id;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/ziine/admin/domain/repository/ArtworkStatusHistoryRepository.java
+++ b/src/main/java/com/ziine/admin/domain/repository/ArtworkStatusHistoryRepository.java
@@ -1,0 +1,10 @@
+package com.ziine.admin.domain.repository;
+
+import com.ziine.admin.domain.entity.ArtworkStatusHistoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ArtworkStatusHistoryRepository extends JpaRepository<ArtworkStatusHistoryEntity, Long> {
+
+}

--- a/src/main/java/com/ziine/admin/presentation/ArtworkReviewController.java
+++ b/src/main/java/com/ziine/admin/presentation/ArtworkReviewController.java
@@ -1,0 +1,27 @@
+package com.ziine.admin.presentation;
+
+import com.ziine.admin.application.ArtworkReviewService;
+import com.ziine.admin.application.dto.request.ArtworkRejectRequestDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/v1/artworks")
+@RequiredArgsConstructor
+public class ArtworkReviewController {
+
+    private final ArtworkReviewService artworkReviewService;
+
+    @PatchMapping("/{artworkId}/approve")
+    public ResponseEntity<Void> approveArtwork(final @PathVariable Long artworkId) {
+        artworkReviewService.approveArtwork(artworkId);
+        return ResponseEntity.noContent()
+            .build();
+    }
+}

--- a/src/main/java/com/ziine/admin/presentation/ArtworkReviewController.java
+++ b/src/main/java/com/ziine/admin/presentation/ArtworkReviewController.java
@@ -11,9 +11,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RestController
-@RequestMapping("/admin/v1/artworks")
 @RequiredArgsConstructor
+@RequestMapping("/admin/v1/artworks")
+@RestController
 public class ArtworkReviewController {
 
     private final ArtworkReviewService artworkReviewService;

--- a/src/main/java/com/ziine/admin/presentation/ArtworkReviewController.java
+++ b/src/main/java/com/ziine/admin/presentation/ArtworkReviewController.java
@@ -24,4 +24,14 @@ public class ArtworkReviewController {
         return ResponseEntity.noContent()
             .build();
     }
+
+    @PatchMapping("/{artworkId}/reject")
+    public ResponseEntity<Void> rejectArtwork(
+        final @PathVariable Long artworkId,
+        final @Valid @RequestBody ArtworkRejectRequestDto artworkRejectRequestDto
+    ) {
+        artworkReviewService.rejectArtwork(artworkId, artworkRejectRequestDto);
+        return ResponseEntity.noContent()
+            .build();
+    }
 }

--- a/src/main/java/com/ziine/artist/domain/repository/ArtistRepository.java
+++ b/src/main/java/com/ziine/artist/domain/repository/ArtistRepository.java
@@ -1,0 +1,10 @@
+package com.ziine.artist.domain.repository;
+
+import com.ziine.artist.domain.entity.ArtistEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ArtistRepository extends JpaRepository<ArtistEntity, Long> {
+
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -24,3 +24,7 @@ spring:
           level: warn
           exclude:
     open-in-view: false
+
+logging:
+  level:
+    org.hibernate.orm.jdbc.bind: trace


### PR DESCRIPTION
### PR 요약  
Artwork 검토 기능을 추가하여 어드민이 작품을 승인 또는 반려할 수 있도록 구현했습니다.  

### 📌 변경 사항  
- `ArtworkReviewService` 추가 (Artwork 승인 및 반려 기능 구현)
- `ArtworkReviewController` 추가 (어드민용 API 제공)
- `ArtworkStatusHistoryRepository` 추가 (Artwork 상태 변경 이력 저장)
- `ArtworkRejectRequestDto` 추가 (`@Valid`를 이용한 반려 사유 검증)
- `ArtistRepository` 추가
- `application-local.yml`에 Hibernate SQL 바인딩 파라미터 로깅 옵션 추가

### ✅ PR Check List  
- `ArtworkStatusHistoryEntity`를 별도 패키지로 분리하여 관리하도록 변경  
- `@Valid`가 정상적으로 동작하지 않는 문제 해결 (`spring-boot-starter-validation` 추가)  
- MySQL 한글 깨짐 현상 해결 (`--skip-character-set-client-handshake` 추가)  
- 승인 및 반려 시 상태 변경을 기록하도록 `ArtworkStatusHistoryEntity` 저장 추가  

### 📌 추가 사항  
- 추후 Spring Event 방식으로 리팩토링하여 상태 변경 로직을 비동기 처리할 계획입니다.  
- `ArtworkNotFoundException`은 `admin` 도메인에서 관리하는 것이 적절하지 않다고 판단하여,  추후 영주님께서 추가해 주시면 해당 예외로 변경할 예정입니다.  (merge 충돌 방지)

혹시 수정이 필요한 부분이 조금이라도 보인다면 편하게 의견 주세요!  😊    