### PR TITLE
Feat: Artwork 상태 기반 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.2'
-    id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.springframework.boot' version '3.3.1'
+    id 'io.spring.dependency-management' version '1.1.5'
 }
 
 group = 'com.example'
@@ -28,8 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa' // Spring Data JPA
     implementation 'org.springframework.boot:spring-boot-starter-web' // Spring MVC
     implementation 'org.springframework.boot:spring-boot-starter-validation' // Spring Validation
-    
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0' // OpenAPI (Swagger UI)
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0' // OpenAPI (Swagger UI)
     implementation 'com.github.joon6093:jpa-nplus1-detector:2.2.0' // JPA N+1 detector
 
     compileOnly 'org.projectlombok:lombok' // Lombok (code generation)

--- a/src/main/java/com/ziine/admin/application/AdminArtworkRetrieveService.java
+++ b/src/main/java/com/ziine/admin/application/AdminArtworkRetrieveService.java
@@ -16,7 +16,7 @@ public class AdminArtworkRetrieveService {
 
     @Transactional(readOnly = true)
     public List<AdminArtworkRetrieveResponseDto> retrieveArtworksByStatus(final ArtworkStatus artworkStatus) {
-        if (artworkStatus == null) {
+        if (artworkStatus == null) {  // TODO. 추후 Querydsl 도입 시 검색 조건을 동적으로 처리
             return artworkRepository.findAllByOrderByCreatedAtAsc()
                 .stream()
                 .map(AdminArtworkRetrieveResponseDto::fromEntity)

--- a/src/main/java/com/ziine/admin/application/AdminArtworkRetrieveService.java
+++ b/src/main/java/com/ziine/admin/application/AdminArtworkRetrieveService.java
@@ -1,0 +1,31 @@
+package com.ziine.admin.application;
+
+import com.ziine.admin.application.dto.response.AdminArtworkRetrieveResponseDto;
+import com.ziine.artwork.domain.entity.ArtworkStatus;
+import com.ziine.artwork.domain.repository.ArtworkRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class AdminArtworkRetrieveService {
+
+    private final ArtworkRepository artworkRepository;
+
+    @Transactional(readOnly = true)
+    public List<AdminArtworkRetrieveResponseDto> retrieveArtworksByStatus(final ArtworkStatus artworkStatus) {
+        if (artworkStatus == null) {
+            return artworkRepository.findAllByOrderByCreatedAtAsc()
+                .stream()
+                .map(AdminArtworkRetrieveResponseDto::fromEntity)
+                .toList();
+        }
+
+        return artworkRepository.findByStatusOrderByCreatedAtAsc(artworkStatus)
+            .stream()
+            .map(AdminArtworkRetrieveResponseDto::fromEntity)
+            .toList();
+    }
+}

--- a/src/main/java/com/ziine/admin/application/dto/response/AdminArtworkRetrieveResponseDto.java
+++ b/src/main/java/com/ziine/admin/application/dto/response/AdminArtworkRetrieveResponseDto.java
@@ -1,0 +1,55 @@
+package com.ziine.admin.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.ziine.artist.domain.entity.ArtistEntity;
+import com.ziine.artwork.domain.entity.ArtworkEntity;
+import com.ziine.artwork.domain.entity.ArtworkStatus;
+import java.time.ZonedDateTime;
+
+public record AdminArtworkRetrieveResponseDto(
+    Long artworkId,
+    String title,
+    String description,
+    String imageUrl,
+    String material,
+    int width,
+    int height,
+    ArtworkStatus artworkStatus,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
+    ZonedDateTime createdAt,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
+    ZonedDateTime modifiedAt,
+    AdminArtworkRetrieveArtistResponseDto artist
+) {
+
+    public static AdminArtworkRetrieveResponseDto fromEntity(final ArtworkEntity artworkEntity) {
+        return new AdminArtworkRetrieveResponseDto(
+            artworkEntity.getId(),
+            artworkEntity.getTitle(),
+            artworkEntity.getDescription(),
+            artworkEntity.getImageUrl(),
+            artworkEntity.getMaterial(),
+            artworkEntity.getSizeAttribute()
+                .getWidth(),
+            artworkEntity.getSizeAttribute()
+                .getHeight(),
+            artworkEntity.getStatus(),
+            artworkEntity.getCreatedAt(),
+            artworkEntity.getModifiedAt(),
+            AdminArtworkRetrieveArtistResponseDto.fromEntity(artworkEntity.getArtistEntity())
+        );
+    }
+
+    public record AdminArtworkRetrieveArtistResponseDto(
+        Long artistId,
+        String name
+    ) {
+
+        public static AdminArtworkRetrieveArtistResponseDto fromEntity(final ArtistEntity artistEntity) {
+            return new AdminArtworkRetrieveArtistResponseDto(
+                artistEntity.getId(),
+                artistEntity.getName()
+            );
+        }
+    }
+}

--- a/src/main/java/com/ziine/admin/presentation/AdminArtworkRetrieveController.java
+++ b/src/main/java/com/ziine/admin/presentation/AdminArtworkRetrieveController.java
@@ -1,0 +1,29 @@
+package com.ziine.admin.presentation;
+
+import com.ziine.admin.application.AdminArtworkRetrieveService;
+import com.ziine.admin.application.dto.response.AdminArtworkRetrieveResponseDto;
+import com.ziine.artwork.domain.entity.ArtworkStatus;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/admin/v1/artworks")
+@RestController
+public class AdminArtworkRetrieveController {
+
+    private final AdminArtworkRetrieveService adminArtworkRetrieveService;
+
+    @GetMapping
+    public ResponseEntity<List<AdminArtworkRetrieveResponseDto>> retrieveArtworks(
+        @RequestParam(required = false) final ArtworkStatus artworkStatus
+    ) {
+        final List<AdminArtworkRetrieveResponseDto> adminArtworkRetrieveResponseDtos =
+            adminArtworkRetrieveService.retrieveArtworksByStatus(artworkStatus);
+        return ResponseEntity.ok(adminArtworkRetrieveResponseDtos);
+    }
+}

--- a/src/main/java/com/ziine/admin/presentation/AdminArtworkReviewController.java
+++ b/src/main/java/com/ziine/admin/presentation/AdminArtworkReviewController.java
@@ -19,7 +19,7 @@ public class AdminArtworkReviewController {
     private final AdminArtworkReviewService adminArtworkReviewService;
 
     @PatchMapping("/{artworkId}/approve")
-    public ResponseEntity<Void> approveArtwork(final @PathVariable Long artworkId) {
+    public ResponseEntity<Void> approveArtwork(@PathVariable final Long artworkId) {
         adminArtworkReviewService.approveArtwork(artworkId);
         return ResponseEntity.noContent()
             .build();
@@ -27,8 +27,8 @@ public class AdminArtworkReviewController {
 
     @PatchMapping("/{artworkId}/reject")
     public ResponseEntity<Void> rejectArtwork(
-        final @PathVariable Long artworkId,
-        final @Valid @RequestBody AdminArtworkRejectRequestDto adminArtworkRejectRequestDto
+        @PathVariable final Long artworkId,
+        @Valid @RequestBody final AdminArtworkRejectRequestDto adminArtworkRejectRequestDto
     ) {
         adminArtworkReviewService.rejectArtwork(artworkId, adminArtworkRejectRequestDto);
         return ResponseEntity.noContent()

--- a/src/main/java/com/ziine/artwork/domain/repository/ArtworkRepository.java
+++ b/src/main/java/com/ziine/artwork/domain/repository/ArtworkRepository.java
@@ -1,10 +1,15 @@
 package com.ziine.artwork.domain.repository;
 
 import com.ziine.artwork.domain.entity.ArtworkEntity;
+import com.ziine.artwork.domain.entity.ArtworkStatus;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ArtworkRepository extends JpaRepository<ArtworkEntity, Long> {
 
+    List<ArtworkEntity> findByStatusOrderByCreatedAtAsc(ArtworkStatus status);
+
+    List<ArtworkEntity> findAllByOrderByCreatedAtAsc();
 }

--- a/src/main/java/com/ziine/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ziine/common/exception/GlobalExceptionHandler.java
@@ -4,7 +4,6 @@ import com.ziine.common.dto.ErrorResponseDto;
 import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpHeaders;
@@ -18,43 +17,43 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @Slf4j
-@RequiredArgsConstructor
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(
-        final MethodArgumentNotValidException e,
-        final HttpHeaders headers,
-        final HttpStatusCode statusCode,
-        final WebRequest request
+        final MethodArgumentNotValidException methodArgumentNotValidException,
+        final HttpHeaders httpHeaders,
+        final HttpStatusCode httpStatusCode,
+        final WebRequest webRequest
     ) {
-        final String message = e.getBindingResult()
+        final String validationErrorMessage = methodArgumentNotValidException.getBindingResult()
             .getAllErrors()
             .stream()
             .map(DefaultMessageSourceResolvable::getDefaultMessage)
             .collect(Collectors.joining(", "));
 
-        final ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(statusCode, message);
+        final ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(httpStatusCode, validationErrorMessage);
 
-        return handleExceptionInternal(e, problemDetail, headers, statusCode, request);
+        return handleExceptionInternal(methodArgumentNotValidException, problemDetail, httpHeaders, httpStatusCode,
+            webRequest);
     }
 
     @Override
     public ResponseEntity<Object> createResponseEntity(
-        final @Nullable Object body,
-        final HttpHeaders headers,
-        final HttpStatusCode statusCode,
-        final WebRequest request
+        final @Nullable Object responseBody,
+        final HttpHeaders httpHeaders,
+        final HttpStatusCode httpStatusCode,
+        final WebRequest webRequest
     ) {
-        if (body instanceof ProblemDetail problemDetail) {
+        if (responseBody instanceof ProblemDetail problemDetail) {
             log.info("[CommonException] URI: {}, Status: {}, Message: {}",
-                request.getDescription(false), statusCode, problemDetail.getDetail());
+                webRequest.getDescription(false), httpStatusCode, problemDetail.getDetail());
 
-            return ResponseEntity.status(statusCode)
+            return ResponseEntity.status(httpStatusCode)
                 .body(new ErrorResponseDto(ErrorCode.BAD_REQUEST.getCode(), problemDetail.getDetail()));
         }
-        log.error("[UnexpectedException] URI: {}, Message: {}", request.getDescription(false), body);
+        log.error("[UnexpectedException] URI: {}, Message: {}", webRequest.getDescription(false), responseBody);
 
         return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
             .body(new ErrorResponseDto(
@@ -63,26 +62,26 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ErrorResponseDto> handleBusinessException(
-        final BusinessException e,
-        final HttpServletRequest request
+        final BusinessException businessException,
+        final HttpServletRequest httpServletRequest
     ) {
         log.info("[BusinessException] URI: {}, Code: {}, Message: {}",
-            request.getRequestURI(), e.getErrorCode()
-                .getCode(), e.getMessage()
+            httpServletRequest.getRequestURI(), businessException.getErrorCode()
+                .getCode(), businessException.getMessage()
         );
 
-        return ResponseEntity.status(e.getErrorCode()
+        return ResponseEntity.status(businessException.getErrorCode()
                 .getHttpStatus())
-            .body(new ErrorResponseDto(e.getErrorCode()));
+            .body(new ErrorResponseDto(businessException.getErrorCode()));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponseDto> handleInternalException(
-        final Exception e,
-        final HttpServletRequest request
+        final Exception exception,
+        final HttpServletRequest httpServletRequest
     ) {
         log.error("[UnexpectedException] URI: {}, Message: {}",
-            request.getRequestURI(), e.getMessage());
+            httpServletRequest.getRequestURI(), exception.getMessage());
 
         return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
             .body(new ErrorResponseDto(ErrorCode.INTERNAL_SERVER_ERROR));


### PR DESCRIPTION
## PR 요약  
Artwork의 상태 기반 조회 기능을 추가하여 어드민이 특정 상태의 작품을 조회할 수 있도록 구현했습니다.  

### 📌 변경 사항  
- `AdminArtworkRetrieveService` 추가 (Artwork 상태별 조회 로직 구현)
- `AdminArtworkRetrieveController` 추가 (어드민용 API 제공)
- `ArtworkRepository`에 `findByStatusOrderByCreatedAtAsc`, `findAllByOrderByCreatedAtAsc` 메서드 추가
- `AdminArtworkRetrieveResponseDto` 추가 (응답 DTO 정의)
- `GlobalExceptionHandler`에서 객체명을 명확하게 명시하도록 변경
- Swagger 문서가 정상적으로 표시되지 않는 문제 해결 (Spring 및 Swagger 버전 조정)

### ✅ PR Check List  
- `createdAt`, `modifiedAt` 필드를 `UTC` 형식으로 반환하도록 설정  
- `@JsonFormat`을 활용하여 `ZonedDateTime`을 `"yyyy-MM-dd'T'HH:mm:ss'Z'"` 형태로 변환  
  (T가 없을 경우 띄어쓰기를 이용해 구분되므로, 일부 환경에서 오류가 발생할 수 있음)  
- Swagger 문서가 정상적으로 로드되지 않는 문제를 해결하기 위해 Spring 및 Swagger 버전 조정  
  ![image](https://github.com/user-attachments/assets/c0f23a72-c7b6-40e6-8181-fc6250c09597)

### 📌 추가 사항  
- 추후 Querydsl 도입 시 동적 쿼리를 활용하여 조회 로직을 개선할 예정입니다.  
- 현재는 `createdAt` 기준 오름차순 정렬만 지원하며, 향후 페이징 기능 도입 시 내림차순 정렬도 함께 고려할 계획입니다.  

PR의 변경 사항 자체는 크지 않지만, 클래스 명과 위치를 어떻게 구성하는 것이 적절할지 고민하느라 예상보다 시간이 걸렸습니다.  
혹시 수정이 필요한 부분이 있거나 추가 의견이 있다면 편하게 공유해주세요! 😊