### PR TITLE
 Feat: Magazine 도메인에 해당하는 엔티티 추가

### DIFF
--- a/src/main/java/com/ziine/api/magazine/domain/entity/KeywordEntity.java
+++ b/src/main/java/com/ziine/api/magazine/domain/entity/KeywordEntity.java
@@ -1,0 +1,43 @@
+package com.ziine.api.magazine.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "keyword")
+public class KeywordEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "keyword_id")
+    private Long id;
+
+    @Column(nullable = false, length = 20)
+    private String tag;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "magazine_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT), nullable = false)
+    private MagazineEntity magazineEntity;
+
+    public KeywordEntity(
+        final String tag,
+        final MagazineEntity magazineEntity
+    ) {
+        this.tag = tag;
+        this.magazineEntity = magazineEntity;
+    }
+}

--- a/src/main/java/com/ziine/api/magazine/domain/entity/MagazineEntity.java
+++ b/src/main/java/com/ziine/api/magazine/domain/entity/MagazineEntity.java
@@ -1,0 +1,66 @@
+package com.ziine.api.magazine.domain.entity;
+
+import com.ziine.global.jpa.domain.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "magazine")
+public class MagazineEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "magazine_id")
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(nullable = false, length = 200)
+    private String summary;
+
+    @Column(nullable = false, length = 255)
+    private String thumbnailImageUrl;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @OneToMany(mappedBy = "magazineEntity", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<KeywordEntity> keywordEntities = new ArrayList<>();
+
+    public MagazineEntity(
+        final String title,
+        final String summary,
+        final String thumbnailImageUrl,
+        final String content,
+        final List<String> keywords
+    ) {
+        this.title = title;
+        this.summary = summary;
+        this.thumbnailImageUrl = thumbnailImageUrl;
+        this.content = content;
+        addKeywords(keywords);
+    }
+
+    private void addKeywords(final List<String> keywords) {
+        keywords.forEach(this::addKeyword);
+    }
+
+    private void addKeyword(final String tag) {
+        this.keywordEntities.add(new KeywordEntity(tag, this));
+    }
+}

--- a/src/main/java/com/ziine/api/magazine/domain/exception/MagazineNotFoundException.java
+++ b/src/main/java/com/ziine/api/magazine/domain/exception/MagazineNotFoundException.java
@@ -1,0 +1,13 @@
+package com.ziine.api.magazine.domain.exception;
+
+import com.ziine.global.error.domain.ErrorCode;
+import com.ziine.global.error.exception.BusinessException;
+
+public class MagazineNotFoundException extends BusinessException {
+
+    public static final MagazineNotFoundException INSTANCE = new MagazineNotFoundException();
+
+    private MagazineNotFoundException() {
+        super(ErrorCode.MAGAZINE_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/ziine/api/magazine/domain/repository/MagazineRepository.java
+++ b/src/main/java/com/ziine/api/magazine/domain/repository/MagazineRepository.java
@@ -1,0 +1,10 @@
+package com.ziine.api.magazine.domain.repository;
+
+import com.ziine.api.magazine.domain.entity.MagazineEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MagazineRepository extends JpaRepository<MagazineEntity, Long> {
+
+}

--- a/src/main/java/com/ziine/global/error/domain/ErrorCode.java
+++ b/src/main/java/com/ziine/global/error/domain/ErrorCode.java
@@ -22,6 +22,11 @@ public enum ErrorCode {
      */
     ADMIN_UNAUTHORIZED(3000, "Unauthorized Admin Access", HttpStatus.UNAUTHORIZED),
     ADMIN_NOT_FOUND(3001, "Admin Not Found", HttpStatus.NOT_FOUND),
+
+    /**
+     * 4XXX -> Magazine 에러
+     */
+    MAGAZINE_NOT_FOUND(4001, "Magazine Not Found", HttpStatus.NOT_FOUND),
     ;
 
     private final int code;


### PR DESCRIPTION
## 📌 PR 요약  
`Magazine` 도메인에 해당하는 엔티티를 추가하였습니다.  
추후 개발을 고려하여 관련 `Repository` 및 `Exception`도 함께 정의하였습니다.  

## 🛠 변경 사항  
- `MagazineEntity` 추가: 매거진 데이터를 관리하는 엔티티  
- `KeywordEntity` 추가: 매거진과 연관된 키워드를 관리하는 엔티티  
- `MagazineRepository` 추가: 매거진 데이터를 관리하기 위한 JPA Repository  
- `MagazineNotFoundException` 추가: 매거진이 존재하지 않을 경우 발생하는 예외  
- `ErrorCode`에 `MAGAZINE_NOT_FOUND` 추가  

## ✅ PR Check List  
- 추후 개발 과정에서의 충돌을 방지하기 위해 `Repository` 및 `Exception`을 미리 추가하였습니다.  

이미 노션에서 논의된 내용이므로 추가적인 논의 없이 바로 반영하겠습니다. 😎