### PR TITLE
Feat: Magazine 저장 기능 구현

### DIFF
--- a/src/main/java/com/ziine/admin/magazine/application/AdminMagazinePersistService.java
+++ b/src/main/java/com/ziine/admin/magazine/application/AdminMagazinePersistService.java
@@ -1,0 +1,22 @@
+package com.ziine.admin.magazine.application;
+
+import com.ziine.admin.magazine.dto.request.AdminMagazinePersistRequestDto;
+import com.ziine.api.magazine.domain.entity.MagazineEntity;
+import com.ziine.api.magazine.domain.repository.MagazineRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class AdminMagazinePersistService {
+
+    private final MagazineRepository magazineRepository;
+
+    public Long persistMagazine(final AdminMagazinePersistRequestDto adminMagazinePersistRequestDto) {
+        final MagazineEntity magazineEntity =
+            MagazineEntity.fromAdminMagazinePersistRequestDto(adminMagazinePersistRequestDto);
+
+        return magazineRepository.save(magazineEntity)
+            .getId();
+    }
+}

--- a/src/main/java/com/ziine/admin/magazine/dto/request/AdminMagazinePersistRequestDto.java
+++ b/src/main/java/com/ziine/admin/magazine/dto/request/AdminMagazinePersistRequestDto.java
@@ -1,0 +1,18 @@
+package com.ziine.admin.magazine.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+public record AdminMagazinePersistRequestDto(
+    @NotBlank(message = "Title is required")
+    String title,
+    @NotBlank(message = "Summary is required")
+    String summary,
+    @NotBlank(message = "Thumbnail image URL is required")
+    String thumbnailImageUrl,
+    @NotBlank(message = "Content is required")
+    String content,
+    List<@NotBlank(message = "Keyword cannot be blank") String> keywords
+) {
+
+}

--- a/src/main/java/com/ziine/admin/magazine/presentation/AdminMagazinePersistController.java
+++ b/src/main/java/com/ziine/admin/magazine/presentation/AdminMagazinePersistController.java
@@ -1,0 +1,29 @@
+package com.ziine.admin.magazine.presentation;
+
+import com.ziine.admin.magazine.application.AdminMagazinePersistService;
+import com.ziine.admin.magazine.dto.request.AdminMagazinePersistRequestDto;
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/admin/v1/magazines")
+@RestController
+public class AdminMagazinePersistController {
+
+    private final AdminMagazinePersistService adminMagazinePersistService;
+
+    @PostMapping
+    public ResponseEntity<Void> persistMagazine(
+        @Valid @RequestBody final AdminMagazinePersistRequestDto adminMagazinePersistRequestDto
+    ) {
+        final Long magazineId = adminMagazinePersistService.persistMagazine(adminMagazinePersistRequestDto);
+        return ResponseEntity.created(URI.create("/api/v1/magazines/" + magazineId))
+            .build();
+    }
+}

--- a/src/main/java/com/ziine/api/magazine/domain/entity/MagazineEntity.java
+++ b/src/main/java/com/ziine/api/magazine/domain/entity/MagazineEntity.java
@@ -1,5 +1,6 @@
 package com.ziine.api.magazine.domain.entity;
 
+import com.ziine.admin.magazine.dto.request.AdminMagazinePersistRequestDto;
 import com.ziine.global.jpa.domain.entity.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -60,5 +61,21 @@ public class MagazineEntity extends BaseEntity {
 
     public void addKeyword(final KeywordEntity keywordEntity) {
         this.keywordEntities.add(keywordEntity);
+    }
+
+    public static MagazineEntity fromAdminMagazinePersistRequestDto(final AdminMagazinePersistRequestDto adminMagazinePersistRequestDto) {
+        final MagazineEntity magazineEntity = new MagazineEntity(
+            adminMagazinePersistRequestDto.title(), adminMagazinePersistRequestDto.summary(),
+            adminMagazinePersistRequestDto.thumbnailImageUrl(), adminMagazinePersistRequestDto.content());
+
+        if (adminMagazinePersistRequestDto.keywords() != null) {
+            final List<KeywordEntity> keywordEntities = adminMagazinePersistRequestDto.keywords()
+                .stream()
+                .map(keyword -> new KeywordEntity(keyword, magazineEntity))
+                .toList();
+            magazineEntity.addKeywords(keywordEntities);
+        }
+        
+        return magazineEntity;
     }
 }


### PR DESCRIPTION
## PR 요약
Admin이 매거진을 등록할 수 있도록 Magazine 등록 기능을 구현하였습니다.

### 📌 변경 사항
- **`AdminMagazinePersistService` 추가**  
  - `AdminMagazinePersistRequestDto`를 받아 `MagazineEntity`로 변환 후 저장  
  - `MagazineEntity.fromAdminMagazinePersistRequestDto()` 메서드를 통해 변환 처리  

- **`AdminMagazinePersistRequestDto` 추가**  
  - 매거진 제목, 요약, 썸네일 이미지 URL, 본문 내용, 키워드를 포함하는 요청 DTO  

- **`AdminMagazinePersistController` 추가**  
  - `POST /admin/v1/magazines` 엔드포인트에서 매거진 등록을 처리  
  - 등록 성공 시 `201 Created` 상태와 함께 생성된 매거진의 URI 반환  

- **`MagazineEntity`에 from 메서드 추가**  
  - `fromAdminMagazinePersistRequestDto()` 메서드를 추가하여 DTO → Entity 변환 처리  
  - `KeywordEntity`와의 관계를 유지하며 키워드 리스트를 함께 저장  

### ✅ PR Check List
컨벤션을 맞추며 진행한 덕분에 원활하게 마무리할 수 있었습니다.  
사소한 부분이라도 개선할 점이 있다면 편하게 말씀해 주세요! 😊
