### PR TITLE
Refactor: 작품 상태(승인, 검토 중, 반려) 이메일 템플릿수정

### DIFF
--- a/src/main/java/com/ziine/api/artwork/application/ArtworkStatusMailService.java
+++ b/src/main/java/com/ziine/api/artwork/application/ArtworkStatusMailService.java
@@ -67,14 +67,14 @@ public class ArtworkStatusMailService {
         variables.put("artistName", artistName);
 
         if (artworkStatusHistoryEntity.getToStatus() == ArtworkStatus.APPROVED) {
-            final String artworkUrl = "https://www.ziine.gallery/artworks/" +
+            final String artworkUrl = "https://www.ziine.gallery/artwork/" +
                 artworkStatusHistoryEntity.getArtworkEntity()
                     .getId();
             variables.put("artworkUrl", artworkUrl);
         }
 
         if (artworkStatusHistoryEntity.getToStatus() == ArtworkStatus.REJECTED) {
-            variables.put("reason", artworkStatusHistoryEntity.getRejectionReason());
+            variables.put("rejectionReason", artworkStatusHistoryEntity.getRejectionReason());
         }
 
         return variables;

--- a/src/main/resources/templates/artwork-approved.html
+++ b/src/main/resources/templates/artwork-approved.html
@@ -2,21 +2,47 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <title>작품 승인 완료</title>
+    <title>작품 승인 안내</title>
 </head>
-<body>
-<h2>작품이 승인되었습니다</h2>
-<p>안녕하세요, <strong th:text="${artistName}"></strong>님.</p>
-<p>귀하의 작품이 승인되었습니다.</p>
-<p>아래 버튼을 눌러 작품을 확인하세요.</p>
+<body style="margin: 0; padding: 0; background-color: #121212; display: flex; justify-content: center; align-items: center; height: 100vh;">
+<div style="width: 600px; padding: 48px; background: #1E1E1E; border-radius: 24px; display: flex; flex-direction: column; align-items: flex-start; gap: 8px;">
 
-<a th:href="${artworkUrl}" style="
-        display: inline-block;
-        padding: 10px 15px;
-        background-color: #4CAF50;
-        color: white;
-        text-decoration: none;
-        border-radius: 5px;
-    ">작품 보러 가기</a>
+    <div style="position: relative;">
+        <img src="https://ziine-bucket.s3.ap-northeast-2.amazonaws.com/assets/ziine-logo.png" alt="Ziine 로고"
+             width="90px"/>
+    </div>
+
+    <div style="color: white; font-size: 36px; font-family: Pretendard, sans-serif; font-weight: 700; line-height: 1.6; position: relative;">
+        작품이 승인되었습니다.
+    </div>
+
+    <div style="color: white; font-size: 18px; font-family: Pretendard, sans-serif; font-weight: 600; line-height: 1.6; position: relative;">
+        안녕하세요, <span th:text="${artistName}" style="font-weight: 700;">{artistName}</span>님,<br/>
+        귀하의 <span style="color: #FF571E; font-weight: 700;">작품이 승인되었습니다.</span><br/>
+        아래 버튼을 눌러 작품을 확인하세요.
+    </div>
+
+    <table width="100%" cellspacing="0" cellpadding="0" border="0" style="margin-top: 24px;">
+        <td align="center" bgcolor="#FF571E" style="border-radius: 12px;">
+            <a th:href="${artworkUrl}" style="
+                                        display: inline-block;
+                                        width: 100%;
+                                        max-width: 500px;
+                                        padding: 15px 0;
+                                        background-color: #FF571E;
+                                        color: white;
+                                        font-size: 18px;
+                                        font-weight: 600;
+                                        text-decoration: none;
+                                        border-radius: 12px;
+                                        text-align: center;
+                                        line-height: 1.6;
+                                        font-family: Pretendard, sans-serif;
+                                        ">작품 보러 가기</a>
+        </td>
+    </table>
+
+</div>
+
 </body>
 </html>

--- a/src/main/resources/templates/artwork-pending.html
+++ b/src/main/resources/templates/artwork-pending.html
@@ -4,10 +4,24 @@
     <meta charset="UTF-8">
     <title>작품 검토 중</title>
 </head>
-<body>
-<h2>작품이 검토 중입니다</h2>
-<p>안녕하세요, <strong th:text="${artistName}"></strong>님.</p>
-<p>귀하의 작품이 현재 검토 중입니다.</p>
-<p>최대 3일 이내에 검토 결과를 안내해 드리겠습니다.</p>
+<body style="margin: 0; padding: 0; background-color: #121212; display: flex; justify-content: center; align-items: center; height: 100vh;">
+<div style="width: 600px; padding: 48px; background: #1E1E1E; border-radius: 24px; display: flex; flex-direction: column; align-items: flex-start; gap: 8px;">
+
+    <div style="position: relative;">
+        <img src="https://ziine-bucket.s3.ap-northeast-2.amazonaws.com/assets/ziine-logo.png" alt="Ziine 로고"
+             width="90px"/>
+    </div>
+
+    <div style="color: white; font-size: 36px; font-family: Pretendard, sans-serif; font-weight: 700; line-height: 1.6;">
+        작품을 검토 중입니다.
+    </div>
+
+    <div style="color: white; font-size: 18px; font-family: Pretendard, sans-serif; font-weight: 600; line-height: 1.6;">
+        안녕하세요, <span th:text="${artistName}" style="font-weight: 700;">{artistName}</span>님,<br/>
+        귀하의 작품을 현재
+        <span style="color: #FF571E;">검토 중</span>입니다.<br/>
+        <span style="color: #FF571E;">최대 3일 이내</span>에 검토 결과를 안내해 드리겠습니다.
+    </div>
+</div>
 </body>
 </html>

--- a/src/main/resources/templates/artwork-rejected.html
+++ b/src/main/resources/templates/artwork-rejected.html
@@ -4,21 +4,35 @@
     <meta charset="UTF-8">
     <title>작품 반려 안내</title>
 </head>
-<body>
-<h2>작품이 반려되었습니다</h2>
-<p>안녕하세요, <strong th:text="${artistName}"></strong>님.</p>
-<p>귀하의 작품이 아쉽게도 반려되었습니다.</p>
+<body style="margin: 0; padding: 0; background-color: #121212; display: flex; justify-content: center; align-items: center; height: 100vh;">
+<div style="width: 600px; padding: 48px; background: #1E1E1E; border-radius: 24px; display: flex; flex-direction: column; align-items: flex-start; gap: 8px;">
 
-<p><strong>반려 사유:</strong></p>
-<blockquote style="
-        background-color: #f8d7da;
-        padding: 10px;
-        border-left: 5px solid #dc3545;
-        color: #721c24;
-    ">
-    <span th:text="${reason}"></span>
-</blockquote>
+    <div style="position: relative;">
+        <img src="https://ziine-bucket.s3.ap-northeast-2.amazonaws.com/assets/ziine-logo.png" alt="Ziine 로고"
+             width="90px"/>
+    </div>
 
-<p>반려 사유를 확인하고 다시 제출해 주세요.</p>
+    <div style="color: white; font-size: 36px; font-family: Pretendard, sans-serif; font-weight: 700; line-height: 1.6; position: relative;">
+        작품이 반려되었습니다.
+    </div>
+
+    <div style="color: white; font-size: 18px; font-family: Pretendard, sans-serif; font-weight: 600; line-height: 1.6; position: relative;">
+        안녕하세요, <span th:text="${artistName}" style="font-weight: 700;">{artistName}</span>님,<br/>
+        귀하의 작품이 아쉽게도 반려되었습니다.<br/>
+        반려 사유를 확인하고 다시 제출해 주세요.
+    </div>
+
+    <div style="color: #FF571E; font-size: 18px; font-weight: 700; margin-top: 8px;">
+        반려 사유:
+    </div>
+
+    <div style="width: 100%; max-width: 570px; background-color: #333333; padding: 15px; border-radius: 12px; position: relative;">
+        <div style="color: white; font-size: 16px; font-weight: 500; line-height: 1.6;">
+            <span th:text="${rejectionReason}">{rejectionReason}</span>
+        </div>
+    </div>
+
+</div>
+
 </body>
 </html>


### PR DESCRIPTION
## PR 요약  
디자이너의 요청에 맞춰 작품 상태(승인, 검토 중, 반려) 이메일 템플릿을 수정하였습니다.

### 📌 변경 사항  
- **`artwork-approved.html`** → 버튼 크기 및 텍스트 간격 조정  
- **`artwork-pending.html`** → 로고 및 텍스트 정렬 수정  
- **`artwork-rejected.html`** → 반려 사유 박스 크기 및 간격 조정  

### ✅ PR Check List  
실제 환경에서 정상적으로 표시됨을 확인했습니다.
<img width="819" alt="image" src="https://github.com/user-attachments/assets/430d75b6-bd40-46f5-bf9a-2b3b7ab55f26" />

넥나잇에서 논의된 내용이므로 추가적인 논의 없이 바로 반영하겠습니다. 😎
