### PR TITLE
Feat: 작가 프로필 이미지 랜덤으로 저장하도록 구현

### DIFF
--- a/src/main/java/com/ziine/api/artist/application/ArtistPersistService.java
+++ b/src/main/java/com/ziine/api/artist/application/ArtistPersistService.java
@@ -3,18 +3,36 @@ package com.ziine.api.artist.application;
 import com.ziine.api.artist.domain.entity.ArtistEntity;
 import com.ziine.api.artist.domain.repository.ArtistRepository;
 import com.ziine.api.artist.dto.ArtistPersistDto;
-import lombok.RequiredArgsConstructor;
+import com.ziine.global.AWSProperties;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@RequiredArgsConstructor
+@EnableConfigurationProperties(AWSProperties.class)
 @Service
 public class ArtistPersistService {
 
     private final ArtistRepository artistRepository;
+    private final AWSProperties awsProperties;
+
+    public ArtistPersistService(
+        ArtistRepository artistRepository,
+        @Qualifier("AWSProperties") AWSProperties awsProperties
+    ) {
+        this.artistRepository = artistRepository;
+        this.awsProperties = awsProperties;
+    }
 
     @Transactional
     public ArtistEntity persistArtist(final ArtistPersistDto artistPersistDto) {
-        return artistRepository.save(ArtistEntity.fromArtistPersistDto(artistPersistDto));
+        return artistRepository.save(
+            ArtistEntity.fromArtistPersistDto(
+                artistPersistDto,
+                awsProperties.getCdn()
+                    .getUrl()
+            )
+        );
     }
+
 }

--- a/src/main/java/com/ziine/api/artist/application/ArtistPersistService.java
+++ b/src/main/java/com/ziine/api/artist/application/ArtistPersistService.java
@@ -4,35 +4,22 @@ import com.ziine.api.artist.domain.entity.ArtistEntity;
 import com.ziine.api.artist.domain.repository.ArtistRepository;
 import com.ziine.api.artist.dto.ArtistPersistDto;
 import com.ziine.global.AWSProperties;
-import org.springframework.beans.factory.annotation.Qualifier;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+@RequiredArgsConstructor
 @EnableConfigurationProperties(AWSProperties.class)
 @Service
 public class ArtistPersistService {
 
     private final ArtistRepository artistRepository;
-    private final AWSProperties awsProperties;
 
-    public ArtistPersistService(
-        ArtistRepository artistRepository,
-        @Qualifier("AWSProperties") AWSProperties awsProperties
-    ) {
-        this.artistRepository = artistRepository;
-        this.awsProperties = awsProperties;
-    }
-
-    @Transactional
     public ArtistEntity persistArtist(final ArtistPersistDto artistPersistDto) {
         return artistRepository.save(
             ArtistEntity.fromArtistPersistDto(
-                artistPersistDto,
-                awsProperties.getCdn()
-                    .getUrl()
+                artistPersistDto
             )
         );
     }
-
 }

--- a/src/main/java/com/ziine/api/artist/domain/ArtistProfileImage.java
+++ b/src/main/java/com/ziine/api/artist/domain/ArtistProfileImage.java
@@ -1,0 +1,27 @@
+package com.ziine.api.artist.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ArtistProfileImage {
+
+    PROFILE_IMAGE_1(1),
+    PROFILE_IMAGE_2(2),
+    PROFILE_IMAGE_3(3);
+    private final int index;
+    private final static String PROFILE_IMAGE_URL_PREFIX = "artist/profile_images/profile_image_";
+    private final static String PROFILE_IMAGE_URL_POSTFIX = ".png";
+
+    public static String generateRandomProfileImage(String cdnUrl) {
+        int randomIndex = (int) (Math.random() * 3);
+        ArtistProfileImage artistProfileImage;
+        switch (randomIndex) {
+            case 0 -> artistProfileImage = PROFILE_IMAGE_1;
+            case 1 -> artistProfileImage = PROFILE_IMAGE_2;
+            default -> artistProfileImage = PROFILE_IMAGE_3;
+        }
+        return cdnUrl + PROFILE_IMAGE_URL_PREFIX + artistProfileImage.getIndex() + PROFILE_IMAGE_URL_POSTFIX;
+    }
+}

--- a/src/main/java/com/ziine/api/artist/domain/entity/ArtistEntity.java
+++ b/src/main/java/com/ziine/api/artist/domain/entity/ArtistEntity.java
@@ -47,16 +47,17 @@ public class ArtistEntity {
 
     public ArtistEntity(
         final String name,
-        final String email
+        final String email,
+        final String cdnUrl
     ) {
         this.name = name;
-        this.profileImageUrl = generateRandomProfileImageUrl(name);
+        this.profileImageUrl = generateRandomProfileImageUrl(cdnUrl);
         this.email = email;
     }
 
-    private String generateRandomProfileImageUrl(final String artistName) {
-        // TODO: 랜덤 이미지 로직 추가 필요
-        return "https://ziine.me/" + artistName + ".png";
+    private String generateRandomProfileImageUrl(final String cdnUrl) {
+        int randomIndex = (int) (Math.random() * 3) + 1;
+        return cdnUrl + "artist/profile_images/profile_image_" + randomIndex + ".png";
     }
 
     public void addEducations(final List<EducationEntity> educationEntities) {
@@ -83,8 +84,12 @@ public class ArtistEntity {
         this.contactEntities.add(contactEntity);
     }
 
-    public static ArtistEntity fromArtistPersistDto(final ArtistPersistDto artistPersistDto) {
-        final ArtistEntity artistEntity = new ArtistEntity(artistPersistDto.artistName(), artistPersistDto.email());
+    public static ArtistEntity fromArtistPersistDto(
+        final ArtistPersistDto artistPersistDto,
+        String cdnUrl
+    ) {
+        final ArtistEntity artistEntity = new ArtistEntity(artistPersistDto.artistName(), artistPersistDto.email(),
+            cdnUrl);
 
         if (artistPersistDto.educations() != null) {
             final List<EducationEntity> educationEntities = artistPersistDto.educations()

--- a/src/main/java/com/ziine/api/artist/domain/entity/ArtistEntity.java
+++ b/src/main/java/com/ziine/api/artist/domain/entity/ArtistEntity.java
@@ -48,16 +48,11 @@ public class ArtistEntity {
     public ArtistEntity(
         final String name,
         final String email,
-        final String cdnUrl
+        final String profileImageUrl
     ) {
         this.name = name;
-        this.profileImageUrl = generateRandomProfileImageUrl(cdnUrl);
+        this.profileImageUrl = profileImageUrl;
         this.email = email;
-    }
-
-    private String generateRandomProfileImageUrl(final String cdnUrl) {
-        int randomIndex = (int) (Math.random() * 3) + 1;
-        return cdnUrl + "artist/profile_images/profile_image_" + randomIndex + ".png";
     }
 
     public void addEducations(final List<EducationEntity> educationEntities) {
@@ -85,11 +80,13 @@ public class ArtistEntity {
     }
 
     public static ArtistEntity fromArtistPersistDto(
-        final ArtistPersistDto artistPersistDto,
-        String cdnUrl
+        final ArtistPersistDto artistPersistDto
     ) {
-        final ArtistEntity artistEntity = new ArtistEntity(artistPersistDto.artistName(), artistPersistDto.email(),
-            cdnUrl);
+        final ArtistEntity artistEntity = new ArtistEntity(
+            artistPersistDto.artistName(),
+            artistPersistDto.email(),
+            artistPersistDto.profileImageUrl()
+        );
 
         if (artistPersistDto.educations() != null) {
             final List<EducationEntity> educationEntities = artistPersistDto.educations()

--- a/src/main/java/com/ziine/api/artist/dto/ArtistPersistDto.java
+++ b/src/main/java/com/ziine/api/artist/dto/ArtistPersistDto.java
@@ -1,5 +1,6 @@
 package com.ziine.api.artist.dto;
 
+import com.ziine.api.artist.domain.ArtistProfileImage;
 import com.ziine.api.artwork.dto.request.ArtworkPersistRequestDto;
 import com.ziine.api.artwork.dto.request.ArtworkPersistRequestDto.ContactRequestDto;
 import com.ziine.api.artwork.dto.request.ArtworkPersistRequestDto.ExhibitionRequestDto;
@@ -10,18 +11,21 @@ public record ArtistPersistDto(
     List<String> educations,
     List<ExhibitionRequestDto> exhibitions,
     List<ContactRequestDto> contacts,
-    String email
+    String email,
+    String profileImageUrl
 ) {
 
     public static ArtistPersistDto fromArtworkPersistRequestDto(
-        final ArtworkPersistRequestDto artworkPersistRequestDto
+        final ArtworkPersistRequestDto artworkPersistRequestDto,
+        final String cdnUrl
     ) {
         return new ArtistPersistDto(
             artworkPersistRequestDto.artistName(),
             artworkPersistRequestDto.educations(),
             artworkPersistRequestDto.exhibitions(),
             artworkPersistRequestDto.contacts(),
-            artworkPersistRequestDto.email()
+            artworkPersistRequestDto.email(),
+            ArtistProfileImage.generateRandomProfileImage(cdnUrl)
         );
     }
 }

--- a/src/main/java/com/ziine/api/artwork/application/ArtworkFacade.java
+++ b/src/main/java/com/ziine/api/artwork/application/ArtworkFacade.java
@@ -8,22 +8,31 @@ import com.ziine.api.artwork.dto.ArtworkPersistDto;
 import com.ziine.api.artwork.dto.response.ArtworkDetailRetrieveResponseDto;
 import com.ziine.api.artwork.dto.response.ArtworksRetrieveResponseDto;
 import com.ziine.api.artwork.dto.request.ArtworkPersistRequestDto;
+import com.ziine.global.AWSProperties;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
+@EnableConfigurationProperties(AWSProperties.class)
 @Service
 public class ArtworkFacade {
 
     private final ArtworkPersistService artworkPersistService;
     private final ArtworkRetrieveService artworkRetrieveService;
     private final ArtistPersistService artistPersistService;
+    private final AWSProperties awsProperties;
 
     @Transactional
     public Long persistArtwork(final ArtworkPersistRequestDto artworkPersistRequestDto) {
         ArtistEntity artistEntity = artistPersistService.persistArtist(
-            ArtistPersistDto.fromArtworkPersistRequestDto(artworkPersistRequestDto));
+            ArtistPersistDto.fromArtworkPersistRequestDto(
+                artworkPersistRequestDto,
+                awsProperties.getCdn()
+                    .getUrl()
+            )
+        );
         ArtworkEntity artworkEntity = artworkPersistService.persistArtwork(
             ArtworkPersistDto.fromArtworkPersistRequestDto(artworkPersistRequestDto), artistEntity);
 

--- a/src/main/java/com/ziine/external/s3/application/S3ServiceImpl.java
+++ b/src/main/java/com/ziine/external/s3/application/S3ServiceImpl.java
@@ -1,6 +1,7 @@
 package com.ziine.external.s3.application;
 
 import com.ziine.api.presigned.dto.PresignedUrl;
+import com.ziine.global.AWSProperties;
 import com.ziine.global.util.UrlUtil;
 import java.time.Duration;
 import java.util.Map;
@@ -15,17 +16,14 @@ public class S3ServiceImpl implements S3Service {
     private static final Duration SIGNATURE_DURATION = Duration.ofMinutes(1);
 
     private final S3Presigner s3Presigner;
-    private final String bucketName;
-    private final String cdnUrl;
+    private final AWSProperties awsProperties;
 
     public S3ServiceImpl(
         final S3Presigner s3Presigner,
-        final String bucketName,
-        final String cdnUrl
+        final AWSProperties awsProperties
     ) {
         this.s3Presigner = s3Presigner;
-        this.bucketName = bucketName;
-        this.cdnUrl = cdnUrl;
+        this.awsProperties = awsProperties;
     }
 
     public PresignedUrl getPresignedUrl(
@@ -35,7 +33,8 @@ public class S3ServiceImpl implements S3Service {
         final String filePath = String.format("artwork/%s", newFileName);
 
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-            .bucket(bucketName)
+            .bucket(awsProperties.getS3()
+                .getBucket())
             .key(filePath)
             .metadata(Map.of(METADATA_KEY_ORIGINAL_NAME, fileName))
             .build();
@@ -48,7 +47,11 @@ public class S3ServiceImpl implements S3Service {
         String presignedUrl = s3Presigner.presignPutObject(preSignRequest)
             .url()
             .toString();
-        String fileUrl = UrlUtil.join(cdnUrl, filePath);
+        String fileUrl = UrlUtil.join(
+            awsProperties.getCdn()
+                .getUrl(),
+            filePath
+        );
 
         return new PresignedUrl(presignedUrl, fileUrl);
     }

--- a/src/main/java/com/ziine/external/s3/config/S3Config.java
+++ b/src/main/java/com/ziine/external/s3/config/S3Config.java
@@ -3,13 +3,16 @@ package com.ziine.external.s3.config;
 import com.ziine.external.s3.application.MockS3Service;
 import com.ziine.external.s3.application.S3Service;
 import com.ziine.external.s3.application.S3ServiceImpl;
-import org.springframework.beans.factory.annotation.Value;
+import com.ziine.global.AWSProperties;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
+@EnableConfigurationProperties(AWSProperties.class)
 public class S3Config {
 
     @Bean
@@ -22,9 +25,8 @@ public class S3Config {
     @ConditionalOnProperty(name = "spring.s3.mock", havingValue = "false", matchIfMissing = true)
     public S3Service s3ServiceImpl(
         final S3Presigner s3Presigner,
-        @Value("${spring.cloud.aws.s3.bucket}") final String bucketName,
-        @Value("${spring.cloud.aws.cdn.url}") final String cdnUrl
+        @Qualifier("AWSProperties") final AWSProperties awsProperties
     ) {
-        return new S3ServiceImpl(s3Presigner, bucketName, cdnUrl);
+        return new S3ServiceImpl(s3Presigner, awsProperties);
     }
 }

--- a/src/main/java/com/ziine/global/AWSProperties.java
+++ b/src/main/java/com/ziine/global/AWSProperties.java
@@ -1,0 +1,30 @@
+package com.ziine.global;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "spring.cloud.aws")
+public class AWSProperties {
+
+    private final S3 s3 = new S3();
+    private final Cdn cdn = new Cdn();
+
+    @Getter
+    @Setter
+    public static class S3 {
+
+        private String bucket;
+    }
+
+    @Getter
+    @Setter
+    public static class Cdn {
+
+        private String url;
+    }
+}

--- a/src/main/java/com/ziine/global/AWSProperties.java
+++ b/src/main/java/com/ziine/global/AWSProperties.java
@@ -1,30 +1,33 @@
 package com.ziine.global;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
+@Primary
 @Getter
 @Setter
 @Configuration
 @ConfigurationProperties(prefix = "spring.cloud.aws")
 public class AWSProperties {
 
-    private final S3 s3 = new S3();
-    private final Cdn cdn = new Cdn();
+    private S3 s3;
+    private Cdn cdn;
 
     @Getter
-    @Setter
+    @RequiredArgsConstructor
     public static class S3 {
 
-        private String bucket;
+        private final String bucket;
     }
 
     @Getter
-    @Setter
+    @RequiredArgsConstructor
     public static class Cdn {
 
-        private String url;
+        private final String url;
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -49,7 +49,7 @@ spring:
         access-key: ${AWS_ACCESS_KEY}
         secret-key: ${AWS_SECRET_KEY}
       cdn:
-        url: ${AWS_CDN_URL}
+        url: https://cdn.ziine.gallery/
 
   s3:
     mock: true


### PR DESCRIPTION
## PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->
작가 프로필 사진 랜덤 저장 로직을 구현했습니다.

#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->
- POST /api/v1/artworks
  - 저장 시 artistProfileImageUrl 필드에 랜덤으로 1~3중 하나의 이미지가 저장됩니다. 

##### ✅ PR check list
<!-- 피드백 받고 싶거나, 공유할 사항을 적어주세요 -->
Entity에 awsProperties 필드 추가가 어색해서 ArtistPersistService에서 주입하도록 구현했는데, 의견 부탁드립니다!


<!-- PR 요청 전 마지막 확인!
- Commit Message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees를 붙여주세요.
- 코드 리뷰가 필요한 사이즈의 PR인지 검토해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
-->