### PR TITLE
Fix: 매거진 배경색 로직 수정

### DIFF
--- a/src/main/java/com/ziine/api/magazine/domain/BackgroundColor.java
+++ b/src/main/java/com/ziine/api/magazine/domain/BackgroundColor.java
@@ -15,14 +15,19 @@ public enum BackgroundColor {
 
     private final String hexColorCode;
 
-    public static BackgroundColor calculateBackgroundColor(int index) {
+    public static BackgroundColor calculateBackgroundColor(
+        int index,
+        int magazineSize
+    ) {
+        boolean isShiftNeeded = ((magazineSize - 1) % BackgroundColor.values().length == 0);
+        int shift = (isShiftNeeded && index == magazineSize - 1) ? 1 : 0;
 
-        return switch (index % 5) {
-            case 0 -> BackgroundColor.GREEN;
-            case 1 -> BackgroundColor.ORANGE;
-            case 2 -> BackgroundColor.PINK;
-            case 3 -> BackgroundColor.SKYBLUE;
-            default -> BackgroundColor.PURPLE;
+        return switch ((index + shift) % 5) {
+            case 0 -> GREEN;
+            case 1 -> ORANGE;
+            case 2 -> PINK;
+            case 3 -> SKYBLUE;
+            default -> PURPLE;
         };
     }
 

--- a/src/main/java/com/ziine/api/magazine/dto/response/MagazinesRetrieveResponseDto.java
+++ b/src/main/java/com/ziine/api/magazine/dto/response/MagazinesRetrieveResponseDto.java
@@ -13,14 +13,18 @@ public record MagazinesRetrieveResponseDto(
 ) {
 
     public static MagazinesRetrieveResponseDto fromEntities(List<MagazineEntity> magazineEntities) {
+        int magazineSize = magazineEntities.size();
         return new MagazinesRetrieveResponseDto(
             magazineEntities.stream()
                 .map(magazineEntity -> MagazineRetrieveDto.fromEntity(
                     magazineEntity,
-                    BackgroundColor.calculateBackgroundColor(magazineEntities.indexOf(magazineEntity))
+                    BackgroundColor.calculateBackgroundColor(
+                        magazineEntities.indexOf(magazineEntity),
+                        magazineSize
+                    )
                 ))
                 .toList(),
-            magazineEntities.size()
+            magazineSize
         );
     }
 


### PR DESCRIPTION
## PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->
매거진 목록 반환 시 인접한 매거진의 색상이 겹치지 않게 로직을 수정했습니다.

#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->
- GET /api/v1/magazines
  - (매거진 총 개수 - 1) 이 5(총 색상의 개수)의 배수라면 마지막 매거진의 색상이 한칸 뒤로 보정됩니다.

##### ✅ PR check list
<!-- 피드백 받고 싶거나, 공유할 사항을 적어주세요 -->


<!-- PR 요청 전 마지막 확인!
- Commit Message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees를 붙여주세요.
- 코드 리뷰가 필요한 사이즈의 PR인지 검토해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
-->